### PR TITLE
fix: added qobrix secret keys to headers middleware

### DIFF
--- a/src/common/configs/dto/config.dto.ts
+++ b/src/common/configs/dto/config.dto.ts
@@ -38,6 +38,12 @@ export class ConfigDto {
   QOBRIX_BASE_URL: string;
 
   @IsString()
+  QOBRIX_API_KEY: string;
+
+  @IsString()
+  QOBRIX_API_USER: string;
+
+  @IsString()
   CLOUDINARY_CLOUD_NAME: string;
 
   @IsString()

--- a/src/middleware/qobrix.middleware.ts
+++ b/src/middleware/qobrix.middleware.ts
@@ -14,6 +14,9 @@ export class QobrixProxyMiddleware implements NestMiddleware {
     private config: ConfigService,
   ) {
     const targetUrl = this.config.get('QOBRIX_BASE_URL');
+    const apiKey = this.config.get('QOBRIX_API_KEY');
+    const apiUser = this.config.get('QOBRIX_API_USER');
+
     this.qobrixProxy = createProxyMiddleware({
       target: targetUrl,
       changeOrigin: true,
@@ -21,6 +24,10 @@ export class QobrixProxyMiddleware implements NestMiddleware {
         '^/qobrix-proxy': '',
       },
       secure: false,
+      onProxyReq: (proxyReq) => {
+        proxyReq.setHeader('X-Api-Key', apiKey);
+        proxyReq.setHeader('X-Api-User', apiUser);
+      },
     });
 
     this.use = this.use.bind(this);


### PR DESCRIPTION
## Describe your changes
- I added the ability to add qobrix secret keys to the request headers in server middleware to avoid sending them from the client for security reasons.

## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://testhomework4.atlassian.net/jira/software/projects/AG/boards/6?assignee=5fd26b3708757f006e4d61d4&selectedIssue=AG-157)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Backend
- [ ] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] use @index decorator for frequently requested data