### PR TITLE
zb-8: add avatar refresh after change

### DIFF
--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -4,3 +4,4 @@ export { UserInfoResponse } from './user-info-response';
 export { type UserSignInResponse } from './user-sign-in-response';
 export { type Lead, type LeadDetailsResponse } from './lead';
 export { type MatchingPropertiesResponse } from './property';
+export { type UserSetAvatarResponse } from './user';

--- a/src/common/types/user/index.ts
+++ b/src/common/types/user/index.ts
@@ -1,0 +1,1 @@
+export { UserSetAvatarResponse } from './user-set-avatar-response';

--- a/src/common/types/user/user-set-avatar-response.ts
+++ b/src/common/types/user/user-set-avatar-response.ts
@@ -1,0 +1,6 @@
+type UserSetAvatarResponse = {
+  avatarUrl: string;
+  avatarPublicId: string;
+};
+
+export { UserSetAvatarResponse };

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -18,7 +18,11 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 
 import { User } from 'src/common/entities/user.entity';
-import { UserAuthResponse, UserSetAvatarResponse } from 'src/common/types';
+import {
+  UserAuthResponse,
+  UserInfoResponse,
+  UserSetAvatarResponse,
+} from 'src/common/types';
 
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
@@ -94,9 +98,9 @@ export class UserController {
   @ApiResponse({ status: 202, description: 'Updated' })
   @ApiResponse({ status: 400, description: 'Bad request' })
   @UsePipes(new ValidationPipe())
-  async updateUser(@Body() userData: UpdateUserDto): Promise<void> {
+  async updateUser(@Body() userData: UpdateUserDto): Promise<UserInfoResponse> {
     try {
-      await this.userService.updateUserData(userData);
+      return await this.userService.updateUserData(userData);
     } catch (error) {
       throw error;
     }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -18,7 +18,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 
 import { User } from 'src/common/entities/user.entity';
-import { UserAuthResponse } from 'src/common/types';
+import { UserAuthResponse, UserSetAvatarResponse } from 'src/common/types';
 
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
@@ -117,9 +117,9 @@ export class UserController {
     )
     file: Express.Multer.File,
     @Body() data: SetAvatarDto,
-  ): Promise<void> {
+  ): Promise<UserSetAvatarResponse> {
     try {
-      await this.userService.setAvatar(file, data);
+      return await this.userService.setAvatar(file, data);
     } catch (error) {
       throw error;
     }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -13,7 +13,7 @@ import { Repository, UpdateResult } from 'typeorm';
 
 import { CloudinaryService } from 'modules/cloudinary/cloudinary.service';
 import { User } from 'src/common/entities/user.entity';
-import { UserAuthResponse } from 'src/common/types';
+import { UserAuthResponse, UserSetAvatarResponse } from 'src/common/types';
 
 import { CreateUserDto } from './dto/create-user.dto';
 import { DeleteAvatarDto } from './dto/delete-avatar.dto';
@@ -186,7 +186,7 @@ export class UserService {
   async setAvatar(
     file: Express.Multer.File,
     data: SetAvatarDto,
-  ): Promise<void> {
+  ): Promise<UserSetAvatarResponse> {
     const { userId, avatarPublicId: oldAvatarPublicId } = data;
 
     try {
@@ -206,7 +206,8 @@ export class UserService {
       const { fileUrl: avatarUrl, filePublicId: avatarPublicId } =
         upoadedAvatarData;
       await this.userRepository.update(userId, { avatarUrl, avatarPublicId });
-      throw new HttpException('Updated', HttpStatus.ACCEPTED);
+
+      return { avatarUrl, avatarPublicId };
     } catch (error) {
       throw error;
     }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -13,7 +13,11 @@ import { Repository, UpdateResult } from 'typeorm';
 
 import { CloudinaryService } from 'modules/cloudinary/cloudinary.service';
 import { User } from 'src/common/entities/user.entity';
-import { UserAuthResponse, UserSetAvatarResponse } from 'src/common/types';
+import {
+  UserAuthResponse,
+  UserInfoResponse,
+  UserSetAvatarResponse,
+} from 'src/common/types';
 
 import { CreateUserDto } from './dto/create-user.dto';
 import { DeleteAvatarDto } from './dto/delete-avatar.dto';
@@ -166,7 +170,7 @@ export class UserService {
     }
   }
 
-  async updateUserData(userData: UpdateUserDto): Promise<void> {
+  async updateUserData(userData: UpdateUserDto): Promise<UserInfoResponse> {
     try {
       const { userId, ...updatedFields } = userData;
       const user = await this.userRepository.findOne({ where: { id: userId } });
@@ -177,7 +181,7 @@ export class UserService {
 
       await this.userRepository.update(userId, updatedFields);
 
-      throw new HttpException('Updated', HttpStatus.ACCEPTED);
+      return await this.userRepository.findOne({ where: { id: userId } });
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
## Describe your changes

Changed return value type of setAvatar endpoint

## Issue ticket code (and/or) and link
- [Link to JIRA ticket](https://testhomework4.atlassian.net/browse/AG-194)

### **General**
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [x] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).



### Backend
- [x] Swagger documentation updated
- [x] Database requests are optimized and not redundant
- [ ] Unit tests written
- [x] use ConfigService instead of process.env
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] use @index decorator for frequently requested data